### PR TITLE
fix: Escape shell arguments for safety

### DIFF
--- a/backend/dockerMailserver.js
+++ b/backend/dockerMailserver.js
@@ -23,6 +23,18 @@ function debugLog(message, data = null) {
 }
 
 /**
+ * Escapes a string for safe use in shell commands by wrapping it in single quotes
+ * and escaping any single quotes within the string
+ * @param {string} arg - Argument to escape
+ * @return {string} Escaped argument safe for shell execution
+ */
+function escapeShellArg(arg) {
+  // Replace single quotes with '\'' (end quote, escaped quote, start quote)
+  // Then wrap the entire string in single quotes
+  return "'" + arg.replace(/'/g, "'\\''") + "'";
+}
+
+/**
  * Executes a command in the docker-mailserver container
  * @param {string} command Command to execute
  * @return {Promise<string>} stdout from the command
@@ -143,7 +155,9 @@ async function getAccounts() {
 async function addAccount(email, password) {
   try {
     debugLog(`Adding new email account: ${email}`);
-    await execSetup(`email add ${email} ${password}`);
+    await execSetup(
+      `email add ${escapeShellArg(email)} ${escapeShellArg(password)}`
+    );
     debugLog(`Account created: ${email}`);
     return { success: true, email };
   } catch (error) {
@@ -157,7 +171,9 @@ async function addAccount(email, password) {
 async function updateAccountPassword(email, password) {
   try {
     debugLog(`Updating password for account: ${email}`);
-    await execSetup(`email update ${email} ${password}`);
+    await execSetup(
+      `email update ${escapeShellArg(email)} ${escapeShellArg(password)}`
+    );
     debugLog(`Password updated for account: ${email}`);
     return { success: true, email };
   } catch (error) {
@@ -171,7 +187,7 @@ async function updateAccountPassword(email, password) {
 async function deleteAccount(email) {
   try {
     debugLog(`Deleting email account: ${email}`);
-    await execSetup(`email del ${email}`);
+    await execSetup(`email del ${escapeShellArg(email)}`);
     debugLog(`Account deleted: ${email}`);
     return { success: true, email };
   } catch (error) {
@@ -229,7 +245,9 @@ async function getAliases() {
 async function addAlias(source, destination) {
   try {
     debugLog(`Adding new alias: ${source} -> ${destination}`);
-    await execSetup(`alias add ${source} ${destination}`);
+    await execSetup(
+      `alias add ${escapeShellArg(source)} ${escapeShellArg(destination)}`
+    );
     debugLog(`Alias created: ${source} -> ${destination}`);
     return { success: true, source, destination };
   } catch (error) {
@@ -243,7 +261,9 @@ async function addAlias(source, destination) {
 async function deleteAlias(source, destination) {
   try {
     debugLog(`Deleting alias: ${source} => ${destination}`);
-    await execSetup(`alias del ${source} ${destination}`);
+    await execSetup(
+      `alias del ${escapeShellArg(source)} ${escapeShellArg(destination)}`
+    );
     debugLog(`Alias deleted: ${source} => ${destination}`);
     return { success: true, source, destination };
   } catch (error) {

--- a/backend/dockerMailserver.js
+++ b/backend/dockerMailserver.js
@@ -31,7 +31,7 @@ function debugLog(message, data = null) {
 function escapeShellArg(arg) {
   // Replace single quotes with '\'' (end quote, escaped quote, start quote)
   // Then wrap the entire string in single quotes
-  return "'" + arg.replace(/'/g, "'\\''") + "'";
+  return `'${arg.replace(/'/g, "'\\''")}'`;
 }
 
 /**


### PR DESCRIPTION
This pull request improves the security of shell command execution in `backend/dockerMailserver.js` by introducing proper escaping of user-supplied arguments. The most important changes include adding a utility function to escape shell arguments and updating all relevant command invocations to use this function, reducing the risk of shell injection vulnerabilities.

Security improvements for shell command execution:

* Added a new `escapeShellArg` function that safely escapes strings for use in shell commands by wrapping them in single quotes and escaping internal quotes.
* Updated `addAccount`, `updateAccountPassword`, and `deleteAccount` functions to use `escapeShellArg` for email and password arguments when invoking shell commands. [[1]](diffhunk://#diff-84c67c789e70504c48a6f1163bdbc6c5e7791807dd4ea46760f36eb3c28c6197L146-R160) [[2]](diffhunk://#diff-84c67c789e70504c48a6f1163bdbc6c5e7791807dd4ea46760f36eb3c28c6197L160-R176) [[3]](diffhunk://#diff-84c67c789e70504c48a6f1163bdbc6c5e7791807dd4ea46760f36eb3c28c6197L174-R190)
* Updated `addAlias` and `deleteAlias` functions to use `escapeShellArg` for source and destination arguments in shell commands. [[1]](diffhunk://#diff-84c67c789e70504c48a6f1163bdbc6c5e7791807dd4ea46760f36eb3c28c6197L232-R250) [[2]](diffhunk://#diff-84c67c789e70504c48a6f1163bdbc6c5e7791807dd4ea46760f36eb3c28c6197L246-R266)